### PR TITLE
Allow redux ^3.0.0 as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-redux": "^5.0.0 || ^6.0.0 || ^7.0.0",
-    "redux": "^4.0.0"
+    "redux": "^3.0.0 || ^4.0.0"
   },
   "scripts": {
     "clean": "rm -rf build",


### PR DESCRIPTION
Allows redux ^3.0.0 as a peerDependency in addition to ^4.0.0. [After reviewing the redux release notes](https://github.com/reduxjs/redux/releases/tag/v4.0.0), I believe it should be harmless to allow either.

(I don't think npm/yarn enforce peer deps, so this isn't a critical PR to merge, just seemed like a nice convenience for consumers still on an older version of redux.)